### PR TITLE
Add 13F Insight to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@
 -   [YNAB](https://www.youneedabudget.com/)
 -   [Ghostfolio](https://github.com/ghostfolio/ghostfolio) - Open Source Wealth Management Software
 -   [SEC API](https://sec-api.io) - query and real-time stream API to access all +18 million SEC filings
+-   [13F Insight](https://13finsight.com/) - Track institutional investor 13F holdings with AI-powered analysis and real-time filing alerts
 -   [ThetaGang](https://github.com/brndnmtthws/thetagang) - Implements "the wheel" options strategy for IBKR\
 -   [Portfolio Visualizer](https://portfoliovisualizer.com) - Run Portfolio Backtests/Simulations
 -   [Find My Moat](https://findmymoat.com/) - Investing Tools Directory


### PR DESCRIPTION
Adds [13F Insight](https://13finsight.com/) to the Tools section.

13F Insight tracks institutional investor 13F holdings filed with the SEC. Features AI-powered position change analysis, filing summaries, and real-time alerts. Complements the existing SEC API entry.