### PR TITLE
Add KeepRule to Websites/Blogs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@
 -   [ThetaGang](https://github.com/brndnmtthws/thetagang) - Implements "the wheel" options strategy for IBKR\
 -   [Portfolio Visualizer](https://portfoliovisualizer.com) - Run Portfolio Backtests/Simulations
 -   [Find My Moat](https://findmymoat.com/) - Investing Tools Directory
+-   [KeepRule](https://keeprule.com/) - AI-powered investment principles platform curating wisdom from 26+ legendary investors including Buffett, Munger, and Dalio, with AI scenario analysis for systematic decision-making
 
 ---
 


### PR DESCRIPTION
## What is KeepRule?

[KeepRule](https://keeprule.com/en/) is a free, curated collection of investment principles and decision rules from master investors including Warren Buffett, Charlie Munger, Ray Dalio, Howard Marks, and others.

## Why it fits this list

- Curates key investment principles from legendary investors into a searchable format
- Organizes principles by real-world decision scenarios (when to buy, when to sell, risk assessment, valuation, etc.)
- Features master investor profiles with their core rules and mental models
- Free to use, actively maintained

## Links

- Website: https://keeprule.com/en/
- Master investors: https://keeprule.com/en/masters
- Decision scenarios: https://keeprule.com/en/scenarios