### PR TITLE
Add KeepRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 -   [Saving Habit](https://savinghabit.com)
 -   [Value Stock Guide](https://valuestockguide.com/)
 -   [Masters Invest](http://mastersinvest.com/)
+-   [KeepRule](https://keeprule.com) - Investment principles and decision-making wisdom from Buffett, Munger, and 26 legendary investors.
 -   [Brooklyn Investor](http://brooklyninvestor.blogspot.in/)
 -   [Street Wise Professor](https://streetwiseprofessor.com/)
 -   [Augmented Trader](https://augmentedtrader.com/)


### PR DESCRIPTION
## Add KeepRule to Websites/Blogs section

- [KeepRule](https://keeprule.com) - Investment principles and decision-making wisdom from Buffett, Munger, and 26 legendary investors.

KeepRule is a free resource that curates investment principles from Warren Buffett, Charlie Munger, and 24 other legendary investors. It organizes their wisdom into structured, searchable principles covering value investing, risk management, and behavioral finance.

**Why it fits this list:** KeepRule is a comprehensive investing education resource focused on the principles and mental models of the world's greatest investors, complementing the books and blogs already listed.