### PR TITLE
Add rebalance to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@
 -   [ThetaGang](https://github.com/brndnmtthws/thetagang) - Implements "the wheel" options strategy for IBKR\
 -   [Portfolio Visualizer](https://portfoliovisualizer.com) - Run Portfolio Backtests/Simulations
 -   [Find My Moat](https://findmymoat.com/) - Investing Tools Directory
+-   [rebalance](https://github.com/cjroth/rebalance) - Interactive portfolio rebalancing TUI that imports brokerage CSV data, sets target allocations, and generates trade instructions. Built with ink-web.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [rebalance](https://github.com/cjroth/rebalance) to the Tools section.

Rebalance is an interactive portfolio rebalancing tool that runs as both a terminal TUI and a web app. It imports brokerage CSV data (Schwab or universal format), lets users review holdings across multiple dimensions (symbol, country, asset class, etc.), set target allocations, and generates exact trade instructions to rebalance their portfolio.

Key features:
- Supports Schwab CSV imports and a universal CSV format
- Multiple rebalancing strategies (proportional, largest-first, etc.)
- All data stays client-side -- nothing is sent to a server
- Built with [ink-web](https://github.com/cjroth/ink-web), runs in both terminal and browser