### PR TITLE
Add KeepRule - Investment principles platform with AI-assisted learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@
 -   [ThetaGang](https://github.com/brndnmtthws/thetagang) - Implements "the wheel" options strategy for IBKR\
 -   [Portfolio Visualizer](https://portfoliovisualizer.com) - Run Portfolio Backtests/Simulations
 -   [Find My Moat](https://findmymoat.com/) - Investing Tools Directory
+-   [KeepRule](https://keeprule.com/) - 1,300+ investment principles from 27 legendary investors organized by scenario, with AI-assisted learning and a free investment psychology test
 
 ---
 


### PR DESCRIPTION
## What is KeepRule?

[KeepRule](https://keeprule.com) is a free investment education platform that organizes principles from 27 legendary investors (Buffett, Munger, Howard Marks, Dalio, Lynch, Klarman, etc.) into a searchable, scenario-based format.

## Why it fits this list

- **1,300+ investment principles** organized by investor and topic
- **95 scenario-based guides** — maps real situations (market crashes, portfolio building, when to sell) to master-level advice
- **Free investment psychology test** based on behavioral finance research
- **AI-assisted learning** grounded in actual investor philosophies
- **Completely free**, no paywall for core features
- Available in 5 languages

## Category

Added to the **Tools** section as it serves as both an educational reference tool and an AI-powered investment learning platform.