### PR TITLE
Add 讀角獸 (Ducorn) — Chinese investment analysis blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 -   [Mr. Money Mustache](http://www.mrmoneymustache.com/)
 -   [Glenn Chan's Random Notes on Investing](https://glennchan.wordpress.com/)
 -   [Fundoo Professor](https://fundooprofessor.wordpress.com/)
+-   [讀角獸 (Ducorn)](https://ducorn.com) - Traditional Chinese investment analysis. Reads English sources (Mauboussin, Kahneman, Tetlock), finds contradictions, writes opinionated judgments. Covers SpaceX IPO valuation, cognitive biases in investing.
 -   [The Finance Buff](https://thefinancebuff.com/)
 -   [Bogleheads Investing Start-up kit](https://www.bogleheads.org/wiki/Bogleheads%C2%AE_investing_start-up_kit)
 -   [Dr. Vijay Malik.com](http://www.drvijaymalik.com/)


### PR DESCRIPTION
Adding 讀角獸 (ducorn.com), a Traditional Chinese publication focused on investment analysis.

Notable articles:
- SpaceX IPO valuation analysis (3 scenarios with Starlink ARPU modeling)
- Investment judgment biases (cross-referencing Mauboussin, Kahneman, Tetlock, Galef)

The site reads English-language investment books and research, finds where sources contradict each other, and publishes opinionated analysis in Chinese.

- Website: https://ducorn.com
- RSS: https://ducorn.com/feed.xml