### PR TITLE
Add Congressional Stock Brain to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@
 -   [ThetaGang](https://github.com/brndnmtthws/thetagang) - Implements "the wheel" options strategy for IBKR\
 -   [Portfolio Visualizer](https://portfoliovisualizer.com) - Run Portfolio Backtests/Simulations
 -   [Find My Moat](https://findmymoat.com/) - Investing Tools Directory
+-   -   [Congressional Stock Brain](https://congressionalstockbrain.com) - Free AI tool that scores every U.S. STOCK Act disclosure by significance. Track what lawmakers buy and sell — ranked by committee relevance, timing, and disclosure delay. No login required.
 
 ---
 


### PR DESCRIPTION
**https://congressionalstockbrain.com**

**Congressional Stock Brain is a free AI-powered tool that scores every U.S. STOCK Act disclosure (publicly filed lawmaker trades) by significance. It tracks what members of Congress buy and sell, ranked by committee relevance, timing vs. legislative activity, trade size vs. historical baseline, and disclosure delay.**

Why it belongs in the Tools section:
- Directly useful to retail investors tracking political trading
- - Free to use, no login required
- - Alongside SEC API — same government financial disclosure ecosystem
- - Covers 800+ lawmakers and 50,000+ disclosed trades
- - AI signal scoring layer makes raw data actionable
# By submitting this pull request I confirm I've read and complied with the below requirements.

- [x] The resource is about investing/finance
- [ ] - [x] The link goes directly to the resource
- [ ] - [x] The description is concise and explains what the resource does