### PR TITLE
Add Helium to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@
 -   [13F Insight](https://13finsight.com/) - Track institutional investor 13F holdings with AI-powered analysis and real-time filing alerts
 -   [ThetaGang](https://github.com/brndnmtthws/thetagang) - Implements "the wheel" options strategy for IBKR
 -   [FlashAlpha](https://flashalpha.com) - Options analytics API for real-time gamma exposure (GEX), delta, vanna, charm, implied volatility, greeks, 0DTE analytics, and dealer positioning. Free tier available
+-   [Helium](https://heliumtrades.com/mcp-page/) - Real-time news with bias scoring across 5,000+ sources, live stock/ETF/crypto data with AI bull/bear cases, ML options pricing, and balanced news synthesis. Available as [MCP server](https://github.com/connerlambden/helium-mcp) or REST API. Free tier available
 -   [rebalance](https://github.com/cjroth/rebalance) - Interactive portfolio rebalancing TUI that imports brokerage CSV data, sets target allocations, and generates trade instructions
 -   [Portfolio Visualizer](https://portfoliovisualizer.com) - Run Portfolio Backtests/Simulations
 -   [Find My Moat](https://findmymoat.com/) - Investing Tools Directory


### PR DESCRIPTION
Adds [Helium](https://heliumtrades.com/mcp-page/) to the Tools section.

Real-time news with bias scoring across 5,000+ sources, live stock/ETF/crypto data with AI-generated bull/bear cases and price forecasts, ML options pricing with probability ITM, and balanced multi-perspective news synthesis. Available as [MCP server](https://github.com/connerlambden/helium-mcp) or REST API with free tier (50 queries, no signup).