### PR TITLE
Add ETF Comparison (thicket.sh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 -   [Find My Moat](https://findmymoat.com/) - Investing Tools Directory
 -   [CalcFi](https://calcfi.app/) - 312+ free financial calculators (compound interest, FIRE number, retirement, investment returns, tax brackets). No signup, no ads.
 -   [FinancialData.Net](https://financialdata.net/) - Financial datasets (stock market data, financial statements, sustainability data, and more).
+-   [ETF Comparison (thicket.sh)](https://etf.thicket.sh/) - Free ETF comparison tool with side-by-side expense ratios, holdings, and performance for popular index funds. No signup, mobile-friendly.
 
 ---
 


### PR DESCRIPTION
**https://etf.thicket.sh/**

**ETF Comparison (thicket.sh)** is a free tool for side-by-side comparison of ETFs — expense ratios, holdings overlap, and historical performance across popular index funds (VOO, VTI, QQQ, SCHD, etc.). Useful for investors researching low-cost index-fund allocation. No signup, no paywall, mobile-friendly.

Added under the existing **Tools** section, matching the `-   [Name](url) - description` format used there.

- [x] I have read the Contribution guidelines and I am confident that my PR is suitable.
- [x] This pull request has a descriptive title. To add a new resource use the title: `Add [resource_name]`
- [x] The resource link I added is not a duplicate.