### PR TITLE
Add Helium MCP to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@
 -   [Portfolio Visualizer](https://portfoliovisualizer.com) - Run Portfolio Backtests/Simulations
 -   [Find My Moat](https://findmymoat.com/) - Investing Tools Directory
 -   [CalcFi](https://calcfi.app/) - 312+ free financial calculators (compound interest, FIRE number, retirement, investment returns, tax brackets). No signup, no ads.
+-   [Helium MCP](https://github.com/connerlambden/helium-mcp) - Free remote MCP server for AI assistants (Cursor, Claude). Per-symbol ML options pricing with prob_ITM, AI-ranked trading strategies with backtested win rates, and 31-dimension news-bias analysis across 3.2M+ articles.
 
 ---
 


### PR DESCRIPTION
Adds [Helium MCP](https://github.com/connerlambden/helium-mcp) under Tools.

Helium MCP is a free remote MCP server for AI assistants (Cursor, Claude Desktop) providing:
- Per-symbol ML options pricing with prob_ITM
- AI-ranked trading strategies with backtested win rates and P&L
- 31-dimension news-bias analysis across 3.2M+ articles

Setup: `npx mcp-remote https://heliumtrades.com/mcp` (no signup, no API key).

Made with [Cursor](https://cursor.com)