### PR TITLE
Add Adanos Market Sentiment API to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@
 -   [ThetaGang](https://github.com/brndnmtthws/thetagang) - Implements "the wheel" options strategy for IBKR
 -   [FlashAlpha](https://flashalpha.com) - Options analytics API for real-time gamma exposure (GEX), delta, vanna, charm, implied volatility, greeks, 0DTE analytics, and dealer positioning. Free tier available
 -   [Helium](https://heliumtrades.com/mcp-page/) - Real-time news with bias scoring across 5,000+ sources, live stock/ETF/crypto data with AI bull/bear cases, ML options pricing, and balanced news synthesis. Available as [MCP server](https://github.com/connerlambden/helium-mcp) or REST API. Free tier available
+-   [Adanos Market Sentiment API](https://api.adanos.org/docs/) - Cross-source stock sentiment API covering Reddit, X, News, and Polymarket with trending, compare, and source-level market context.
 -   [rebalance](https://github.com/cjroth/rebalance) - Interactive portfolio rebalancing TUI that imports brokerage CSV data, sets target allocations, and generates trade instructions
 -   [Portfolio Visualizer](https://portfoliovisualizer.com) - Run Portfolio Backtests/Simulations
 -   [Find My Moat](https://findmymoat.com/) - Investing Tools Directory


### PR DESCRIPTION
## Summary
- add Adanos Market Sentiment API to the Tools section
- position it as a stock sentiment and market context API across Reddit, X, News, and Polymarket

## Why
Adanos fits the existing investing tools section as an API for sentiment-driven research and cross-source market context.
