### PR TITLE
Add DeepAlpha - AI crypto trading bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@
 -   [Portfolio Visualizer](https://portfoliovisualizer.com) - Run Portfolio Backtests/Simulations
 -   [Find My Moat](https://findmymoat.com/) - Investing Tools Directory
 -   [CalcFi](https://calcfi.app/) - 312+ free financial calculators (compound interest, FIRE number, retirement, investment returns, tax brackets). No signup, no ads.
+-   [DeepAlpha](https://github.com/stefanoviana/deepalpha) - Open source AI crypto trading bot with ML ensemble (XGBoost, LightGBM, CatBoost). 3 bot types (AI, Grid, DCA), 12 exchanges, Telegram control. [PyPI](https://pypi.org/project/deepalpha/)
 -   [FinancialData.Net](https://financialdata.net/) - Financial datasets (stock market data, financial statements, sustainability data, and more).
 
 ---


### PR DESCRIPTION
## Add DeepAlpha to Tools section

[DeepAlpha](https://github.com/stefanoviana/deepalpha) is an open-source AI-powered crypto trading bot with ML ensemble models.

**Features:**
- ML ensemble: XGBoost, LightGBM, CatBoost
- 3 bot types: AI (ML-driven), Grid trading, DCA
- 12 exchange support via CCXT
- Telegram bot control
- Available on [PyPI](https://pypi.org/project/deepalpha/)
- Live demo: [deepalphabot.com](https://deepalphabot.com)

Fits in the Tools section alongside other trading and investment tools like Zipline, ta-lib, and ThetaGang.