### PR TITLE
Add StockVektor to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 -   [Find My Moat](https://findmymoat.com/) - Investing Tools Directory
 -   [CalcFi](https://calcfi.app/) - 312+ free financial calculators (compound interest, FIRE number, retirement, investment returns, tax brackets). No signup, no ads.
 -   [FinancialData.Net](https://financialdata.net/) - Financial datasets (stock market data, financial statements, sustainability data, and more).
+-   [StockVektor](https://stockvektor.com) - Free stock research tool covering ~1,300 US stocks with proprietary quality scores (Piotroski, Altman, Beneish, ROIC) derived from SEC EDGAR data, plus insider buying clusters, 13F super-investor overlap, and pattern surfaces like cheap compounders and hidden margin expansion.
 
 ---
 


### PR DESCRIPTION
Adds StockVektor (https://stockvektor.com) to the Tools section.

Free stock research tool covering ~1,300 US stocks. Computes proprietary quality scores (Piotroski, Altman, Beneish, ROIC) from SEC EDGAR data. Surfaces insider buying clusters, 13F super-investor overlap, and named investment patterns (cheap compounders, hidden margin expansion).

Fills a gap for fundamental and quant-leaning individual investors between basic screeners and paid platforms.