### PR TITLE
Add Not Very Private Equity

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@
 -   [PrimeInvestor](https://primeinvestor.in)
 -   [KeepRule](https://keeprule.com) - Free database of 1,377 investment principles from 26 legendary investors including Buffett, Munger, Graham, and Dalio. Features AI chat, psychology tests, and master comparisons.
 -   [The Stock Radar](https://thestockradar.com) - Daily multi-language stock analysis covering 6 markets (US, Korea, Japan, Taiwan, India, Germany). Technical and fundamental coverage of daily movers, sector rotation, earnings, and weekly research reports — published in 6 languages.
+-   -   [Not Very Private Equity](https://notveryprivateequity.com/)
 
 ### Courses
 


### PR DESCRIPTION
**https://notveryprivateequity.com/**

**Not Very Private Equity is a free weekly newsletter covering private equity deal flow, investment theses, fund mechanics (carried interest, two-and-twenty, LBO models, NAV lending, continuation funds), and operator economics. ~830 subscribers, no paywall, no signup required to view. Fits the Websites/Blogs section as a PE-focused niche addition alongside the existing investing-focused entries.**

# By submitting this pull request I confirm I've read and complied with the below requirements.

Failure to properly do so will just result in the pull request being closed and everyone's time wasted. Please read it twice. Most people miss many things.

- [x] I have read the [Contribution guidelines](https://github.com/mr-karan/awesome-investing/blob/master/contributing.md) and I am confident that my PR is suitable.
- [x] This pull request has a descriptive title. To add a new resource use the title: `Add [resource_name]`
- [x] The resource link I added is not a duplicate.