### PR TITLE
Add Section 16 Deadline Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@
 -   [Ghostfolio](https://github.com/ghostfolio/ghostfolio) - Open Source Wealth Management Software
 -   [FXMacroData](https://fxmacrodata.com/) - Macroeconomic and FX data API with central bank announcements, rates, inflation, employment, GDP, and release calendars for 18 currencies
 -   [SEC API](https://sec-api.io) - query and real-time stream API to access all +18 million SEC filings
+-   [Section 16 Deadline Calculator](https://section-16-deadline-calculator.vercel.app/) - No-login local calculator for common SEC Forms 3, 4, and 5 deadline planning, with memo, CSV, and ICS calendar exports.
 -   [13F Insight](https://13finsight.com/) - Track institutional investor 13F holdings with AI-powered analysis and real-time filing alerts
 -   [ThetaGang](https://github.com/brndnmtthws/thetagang) - Implements "the wheel" options strategy for IBKR
 -   [FlashAlpha](https://flashalpha.com) - Options analytics API for real-time gamma exposure (GEX), delta, vanna, charm, implied volatility, greeks, 0DTE analytics, and dealer positioning. Free tier available


### PR DESCRIPTION
Adds Section 16 Deadline Calculator to the Tools section. It is a no-login local calculator for common SEC Forms 3, 4, and 5 deadline planning, with memo, CSV, and ICS calendar exports.\n\nI built and maintain this tool. I checked the current README and open PRs for duplicates; the adjacent Form 4/insider alert tools are different from this deadline-planning calculator.\n\nChecklist:\n\n- Read the contribution guidelines.\n- Confirmed the resource fits the investing/finance tools list.\n- Confirmed this is not a duplicate link.